### PR TITLE
Update centroid.inx

### DIFF
--- a/centroid.inx
+++ b/centroid.inx
@@ -2,7 +2,7 @@
 <inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
   <_name>Centroid</_name>
   <id>com.github.thedatachef.inkscape-centroid</id>
-  <dependency type="executable" location="extensions">centroid.rb</dependency>
+  <dependency type="executable" location="extensions">centroid.py</dependency>
   <param name="num_points" type="int" min="10" max="1000" _gui-text="Number of linear segments per curve">100</param>
   <param name="centroid_radius" type="int" min="1" max="100" _gui-text="Radius of output centroid">10</param>
   <effect>


### PR DESCRIPTION
INX file had typo in dependency line, so extension could never be loaded.
